### PR TITLE
fix: reorganize CLI runner and update imports

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -474,7 +474,7 @@ description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"base-asgi\" or extra == \"uvicorn\" or extra == \"hypercorn\""
+markers = "extra == \"hypercorn\" or extra == \"base-asgi\" or extra == \"uvicorn\""
 files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
@@ -490,6 +490,7 @@ groups = ["main"]
 markers = "extra == \"hypercorn\""
 files = [
     {file = "h2-4.2.0-py3-none-any.whl", hash = "sha256:479a53ad425bb29af087f3458a61d30780bc818e4ebcf01f0b536ba916462ed0"},
+    {file = "h2-4.2.0.tar.gz", hash = "sha256:c8a52129695e88b1a0578d8d2cc6842bbd79128ac685463b887ee278126ad01f"},
 ]
 
 [package.dependencies]
@@ -1454,6 +1455,70 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "rloop"
+version = "0.1.0"
+description = "An asyncio event loop implemented in Rust"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "rloop-0.1.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:feef98bd9894748819c4ade00cabbcdc358bcc3e0bc000f093f4678ce2b59229"},
+    {file = "rloop-0.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:732e85c238efed34a2f5052dd12e2e0e251763eb334b08b1b326ad650bfec6c9"},
+    {file = "rloop-0.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:062e761957be24843e34ec14dc7bda27e5d282e55e4fa71a4f5f96f9c30ea255"},
+    {file = "rloop-0.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a12d63fbd11d90aa8ee7055d021e199cb0213a21abe3ea49354845264d26196"},
+    {file = "rloop-0.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d4d3c10f91262de263321693d478a7a2e959132d7cbab4eca6e12340b822f62a"},
+    {file = "rloop-0.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3a3e70bf655f51b2daab48393071737af47ae88e8607747823bbde5ea1f53487"},
+    {file = "rloop-0.1.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:16f3ed026a3dcb2d644a7423542a99bff3c08a9417f0df00236f0a01d76c97a8"},
+    {file = "rloop-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d7222b5c9cc3ccf95983b9b07543f4525653f0c84f5d9afecd7ea20ce8ed7d72"},
+    {file = "rloop-0.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da028cafface0a404891a57a412e8ec4a83d73a86ecd37cecbd1bff230c5b9df"},
+    {file = "rloop-0.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c29c91e9deaa573ed73cdfc862014d2ec66a83353c4180456479adbcccad6a0"},
+    {file = "rloop-0.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:27f11139d6b568c2bf90629728790099470f4c4967ce25d4cd824750469cfa66"},
+    {file = "rloop-0.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2031d51b0bee249f3ac5f779fb145ff3ee31e5b74d36bd345db797ac9bdedd87"},
+    {file = "rloop-0.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:7aee48495aa6aca41fc7776f3c81c291cbbe1ce0c41c6df76c98f727e643a301"},
+    {file = "rloop-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:46740b4a1a9af2a3820a183fac89f638803407298c23c25c1d0d6b525c737209"},
+    {file = "rloop-0.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebabe285bb0b61ff7385dd868f7aab1977d0b6a4c3ab77e3a0d866f09b401422"},
+    {file = "rloop-0.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:520d7355a0248903006bf96313761bba2a7de35c0ad4cfdb76d7b4da7fecacbb"},
+    {file = "rloop-0.1.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:515a7b748472238d245133399f77eb46e93c851c86867fbfc23db71270defcd0"},
+    {file = "rloop-0.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3f8e5573d80458fd5ff316fa84d978c5af4761cc1277fc4e8bfaae42c52a0a56"},
+    {file = "rloop-0.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8d05ab370f990ab4d9aece2e87f2dd48365b85c4a3437df2c11ac8e293284e93"},
+    {file = "rloop-0.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f59d200af6f708d35156f1866f3ad8b71237388203cff639800ad0b4bb62748e"},
+    {file = "rloop-0.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fabf99eedf9066829b99a8b322eda749e01a456861e848d881df01576c6a946a"},
+    {file = "rloop-0.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e8b4f75b867e523021f0d3ad5e02f6e2b57fc7e4d94502ae3551c5628ad9b7e"},
+    {file = "rloop-0.1.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:8ded3c44ff9e85676ec7314dc7caff283dcd92ff0098646993d153e419d9548b"},
+    {file = "rloop-0.1.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:dfd8f62d344c8ae2b6c86a08d36d6c729d660a3f91c95c60edf8d1e587cf5df9"},
+    {file = "rloop-0.1.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:8023d8e518a599e492300af9ed567e249f8f976ba518aeb860da96633b5b354d"},
+    {file = "rloop-0.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f3440cbdb42ea666dd3620ce60ebd5f2e4423e865c37443eaceb3f373492497b"},
+    {file = "rloop-0.1.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f71875107c58bc9732b0769f9153b971970705a06d1ff99d74a7fab526a77a07"},
+    {file = "rloop-0.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fdbb97939cb816dd71bd056b425b816ebd6292ecdd7e16a291f703fac110d54"},
+    {file = "rloop-0.1.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:fbfa5c779f63126d73f03935c1211fa1f0063f2a933fc7a264e6763acd0fed99"},
+    {file = "rloop-0.1.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:da69383c9e08530b94da09253580eb3afbe7fdc0631d30844cf70b90b8748ac3"},
+    {file = "rloop-0.1.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:07e2fa905992fd6c97e922dab93d266df7a2b66483265f1b9648c6e4d019dc7e"},
+    {file = "rloop-0.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e409a70cf31ed7995e61536efb5106b859dd17579ada794a1844a19347dcbf4e"},
+    {file = "rloop-0.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dfd4740a894f1b294dce8554f509d57e11df09eccdb528e9cfc847138271e35"},
+    {file = "rloop-0.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92a8aaeb2c186a9a70abc26450c6d96d36ce556c0821f18203a981aa453fea08"},
+    {file = "rloop-0.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18c28b2795229ad450133482d54a5781e6112dd54bcd567c4e3407b723fc94bc"},
+    {file = "rloop-0.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5ba297465828ade1f8b8550c42f4421b704aa8a19c57a318cbfd9cdf175dec1b"},
+    {file = "rloop-0.1.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9f08e382a45b21abd132df546005e1b2ee69c8fde2e0e37f254aff9c82cecf3e"},
+    {file = "rloop-0.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:89a57311db107856007c94bf8dae63cdd2c0ba204970bf449f03d6ced5e3b1d8"},
+    {file = "rloop-0.1.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ec3c8aa2a570dddb4d6787d4ae9e752ff5161413d7fbc46efce00a78cb2254e"},
+    {file = "rloop-0.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6baee543a8c8d4e8fe0510bcc170d8212206d05418ae655a5f92dcbfac74f60c"},
+    {file = "rloop-0.1.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:af57c69abd88093eedf4a7ef02268a1395024c1d5ded863c73b6ed13263de408"},
+    {file = "rloop-0.1.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:cba3fb863114ca71175013e073776821c13eaf3314fab0659e5299bb533fc7e1"},
+    {file = "rloop-0.1.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ec40b093032af3b42a175f347af7e69bddce51139732863d397341223477af7d"},
+    {file = "rloop-0.1.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e2306f3fa322418e6690917dc776b1442ce2f654a0cb5f09ccf1bbe23a8002da"},
+    {file = "rloop-0.1.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:906daaa2a05360ed95102ee14d97c101aee77624fa86537e12c30dc5fc4c8dec"},
+    {file = "rloop-0.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9248a3a745bad06387fb2b0c439743562ddd6da94303d4800eee7a5ddae17e0f"},
+    {file = "rloop-0.1.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:ca61c97d7a5d864bd998353ad6bea58e025043434307cadde78da5bdd09d3d1c"},
+    {file = "rloop-0.1.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:059acfa329f6ad91d2fc269235f8bb2cfc6ba2af9a0df3b71b89b09edb210ca4"},
+    {file = "rloop-0.1.0.tar.gz", hash = "sha256:ab9f98f6e4e1df18dd7399a96024f8cfbe1d3c2e92e7177aaa53fb68d3f075b6"},
+]
+
+[package.extras]
+dev = ["rloop[lint,test]"]
+lint = ["ruff (>=0.5.0,<0.6.0)"]
+test = ["pytest (>=7.4.2,<7.5.0)", "pytest-asyncio (>=0.21.1,<0.22.0)"]
+
+[[package]]
 name = "ruamel-yaml"
 version = "0.18.10"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
@@ -1935,4 +2000,4 @@ uvloop = ["uvloop"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "ddab9d2f666c51e787629b3c444dc2a2dbb6e17bf898457dce37505d533ae8e7"
+content-hash = "0af80502f0759415332b74bbbbb2f08d96ea3fcc997f1cb05154b6aa63299400"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "temporal-boost"
 packages = [{include = "temporal_boost"}]
 readme = "README.md"
 repository = "https://github.com/northpowered/temporal-boost"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -23,15 +23,16 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-granian = {version = "^2.0.0", optional = true}
-hypercorn = {version = "^0.17.0", optional = true}
-pydantic = "^2.10.0"
 python = "^3.10.0"
+pydantic = "^2.10.0"
 pyyaml = "^6.0.0"
 temporalio = "^1.10.0"
 typer = "^0.15.0"
-uvicorn = {version = "^0.30.0", optional = true}
-uvloop = {version = "^0.21.0", optional = true}
+hypercorn = {version = "*", optional = true}
+granian = {version = "*", optional = true}
+uvicorn = {version = "*", optional = true}
+uvloop = {version = "*", optional = true}
+rloop = {version = "*", optional = true}
 
 [tool.poetry.extras]
 base_asgi = ["uvicorn", "uvloop"]
@@ -41,7 +42,7 @@ uvicorn = ["uvicorn"]
 uvloop = ["uvloop"]
 
 [tool.poetry.scripts]
-temporal-boost = "temporal_boost.__main__:cli"
+temporal-boost = "temporal_boost.cli.runner:cli_app"
 
 [tool.poetry.group.dev.dependencies]
 fastapi = "^0.110.0"

--- a/temporal_boost/__main__.py
+++ b/temporal_boost/__main__.py
@@ -1,5 +1,0 @@
-from temporal_boost.cli.runner import cli
-
-
-if __name__ == "__main__":
-    cli()

--- a/temporal_boost/_loops.py
+++ b/temporal_boost/_loops.py
@@ -17,6 +17,7 @@ class Loops(str, Enum):
     auto = "auto"
     asyncio = "asyncio"
     uvloop = "uvloop"
+    rloop = "rloop"
 
 
 class BaseRegistry(Generic[T]):
@@ -91,8 +92,17 @@ def build_uv_loop(uvloop: Any) -> Any:
     return uvloop.new_event_loop()
 
 
+@loops.register("rloop", packages=["rloop"])
+def build_rloop(rloop: Any) -> Any:
+    loop = rloop.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
 @loops.register("auto")
 def build_auto_loop() -> asyncio.AbstractEventLoop:
     if "uvloop" in loops:
         return loops.get("uvloop")
+    if "rloop" in loops:
+        return loops.get("rloop")
     return loops.get("asyncio")

--- a/temporal_boost/cli/importer.py
+++ b/temporal_boost/cli/importer.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def import_app_object(app_path: str) -> Any:
+    try:
+        module_str, attribute_path = app_path.split(":", 1)
+    except ValueError as exc:
+        raise ValueError(f'Import string "{app_path}" must be in format "<module>:<attribute>".') from exc
+
+    if not module_str or not attribute_path:
+        raise ValueError(f'Import string "{app_path}" must be in format "<module>:<attribute>".')
+
+    try:
+        module = importlib.import_module(module_str)
+    except ModuleNotFoundError as exc:
+        candidates: list[Path] = []
+        current_working_dir = Path.cwd()
+        first_segment = module_str.split(".")[0]
+        if (current_working_dir / first_segment).exists():
+            candidates.append(current_working_dir)
+        candidates.append(current_working_dir.parent)
+        for candidate in candidates:
+            candidate_str = str(candidate.resolve())
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            try:
+                module = importlib.import_module(module_str)
+                break
+            except ModuleNotFoundError:
+                continue
+        else:
+            raise ValueError(f'Could not import module "{module_str}".') from exc
+
+    instance: Any = module
+    for attribute in attribute_path.split("."):
+        if not hasattr(instance, attribute):
+            raise ValueError(f'Attribute "{attribute_path}" not found in module "{module_str}".')
+        instance = getattr(instance, attribute)
+    return instance

--- a/temporal_boost/cli/process_runner.py
+++ b/temporal_boost/cli/process_runner.py
@@ -1,0 +1,20 @@
+from multiprocessing import Process
+
+from temporal_boost.cli.importer import import_app_object
+from temporal_boost.cli.prometheus import setup_prometheus_multiproc_dir
+
+
+def run_single_process(app_path: str, arguments: list[str]) -> None:
+    application_object = import_app_object(app_path)
+    application_object.run(arguments)
+
+
+def run_multiprocess(app_path: str, number_of_processes: int, arguments: list[str]) -> None:
+    setup_prometheus_multiproc_dir()
+    process_collection: list[Process] = []
+    for index in range(number_of_processes):
+        process = Process(target=run_single_process, args=(app_path, arguments), name=f"worker-{index}")
+        process_collection.append(process)
+        process.start()
+    for process in process_collection:
+        process.join()

--- a/temporal_boost/cli/prometheus.py
+++ b/temporal_boost/cli/prometheus.py
@@ -1,0 +1,30 @@
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+
+def setup_prometheus_multiproc_dir() -> None:
+    prometheus_dir = os.getenv("PROMETHEUS_MULTIPROC_DIR")
+    if prometheus_dir:
+        directory_path = Path(prometheus_dir)
+        if not directory_path.exists():
+            try:
+                directory_path.mkdir(parents=True, exist_ok=True)
+                logger.info(f"Created Prometheus multiprocess directory at {prometheus_dir}")
+            except Exception as exception_detail:
+                logger.warning(
+                    f"Cannot create Prometheus multiprocess directory '{prometheus_dir}': {exception_detail}"
+                )
+                del os.environ["PROMETHEUS_MULTIPROC_DIR"]
+                logger.warning("Unset PROMETHEUS_MULTIPROC_DIR due to errors")
+    else:
+        try:
+            temporary_directory = tempfile.mkdtemp(prefix="prometheus_multiproc_")
+            os.environ["PROMETHEUS_MULTIPROC_DIR"] = temporary_directory
+            logger.info(f"Set temporary PROMETHEUS_MULTIPROC_DIR at {temporary_directory}")
+        except Exception as exception_detail:
+            logger.warning(f"Failed to set temporary PROMETHEUS_MULTIPROC_DIR: {exception_detail}")

--- a/temporal_boost/cli/runner.py
+++ b/temporal_boost/cli/runner.py
@@ -1,86 +1,23 @@
-import importlib
 import logging
-import os
-import tempfile
-from multiprocessing import Process
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 import typer
 
-
-if TYPE_CHECKING:
-    from types import ModuleType
+from temporal_boost.cli.process_runner import run_multiprocess, run_single_process
 
 
 logger = logging.getLogger(__name__)
-cli = typer.Typer(help="CLI runner for BoostApp services")
+cli_app = typer.Typer(help="CLI runner for BoostApp services")
 
 
-def setup_prometheus_multiproc_dir() -> None:
-    prometheus_dir = os.getenv("PROMETHEUS_MULTIPROC_DIR")
-
-    if prometheus_dir:
-        path = Path(prometheus_dir)
-        if not path.exists():
-            try:
-                path.mkdir(parents=True, exist_ok=True)
-                logger.info(f"Created prometheus multiprocess dir at {prometheus_dir}")
-            except Exception as e:
-                logger.warning(f"Cannot create prometheus multiprocess dir '{prometheus_dir}': {e}")
-                del os.environ["PROMETHEUS_MULTIPROC_DIR"]
-                logger.warning("Unset PROMETHEUS_MULTIPROC_DIR due to errors")
-    else:
-        try:
-            temp_dir = tempfile.mkdtemp(prefix="prometheus_multiproc_")
-            os.environ["PROMETHEUS_MULTIPROC_DIR"] = temp_dir
-            logger.info(f"Set temporary PROMETHEUS_MULTIPROC_DIR at {temp_dir}")
-        except Exception as e:
-            logger.warning(f"Failed to set temporary PROMETHEUS_MULTIPROC_DIR: {e}")
-
-
-def _import_app_object(app_path: str) -> Any:
-    if ":" not in app_path:
-        raise typer.BadParameter("App path must be in format 'module.submodule:app'")
-    module_path, app_attr = app_path.split(":")
-    module: ModuleType = importlib.import_module(module_path)
-    app = getattr(module, app_attr, None)
-    if app is None:
-        raise typer.BadParameter(f"No '{app_attr}' found in module '{module_path}'")
-    return app
-
-
-def _run_single(app_path: str, run_args: list[str]) -> None:
-    app = _import_app_object(app_path)
-    app.run(run_args)
-
-
-def _run_multiprocess(app_path: str, processes: int, run_args: list[str]) -> None:
-    setup_prometheus_multiproc_dir()
-
-    process_list: list[Process] = []
-    for index in range(processes):
-        process = Process(target=_run_single, args=(app_path, run_args), name=f"worker-{index}")
-        process_list.append(process)
-        process.start()
-
-    for process in process_list:
-        process.join()
-
-
-@cli.command("run")
-def run(
+@cli_app.command("run")
+def run_command(
     app: str = typer.Argument(..., help="Path to BoostApp, e.g. 'my_app.app:app'"),
     workers: int = typer.Option(1, "--workers", "-w", help="Number of processes to run"),
-    run_args: list[str] = typer.Argument(None, help="Additional arguments to pass to app.run()", show_default=False),  # noqa: B008
+    arguments: list[str] = typer.Argument(None, help="Additional arguments to pass to app.run()", show_default=False),  # noqa: B008
 ) -> None:
-    additional_args = run_args or []
+    additional_arguments = arguments or []
     if workers > 1:
-        logger.info(f"Starting {workers} processes for app '{app}' with arguments: {additional_args}")
-        _run_multiprocess(app, workers, additional_args)
+        logger.info(f"Starting {workers} processes for app '{app}' with arguments: {additional_arguments}")
+        run_multiprocess(app, workers, additional_arguments)
     else:
-        _run_single(app, additional_args)
-
-
-if __name__ == "__main__":
-    cli()
+        run_single_process(app, additional_arguments)

--- a/temporal_boost/temporal/client.py
+++ b/temporal_boost/temporal/client.py
@@ -55,12 +55,18 @@ class TemporalClientBuilder:
     def set_identity(self, identity: str) -> None:
         self._identity = identity
 
+    def set_kwargs(self, **kwargs: Any) -> None:
+        self._client_kwargs.update(kwargs)
+
     def set_pydantic_data_converter(self) -> None:
         self._data_converter = pydantic_data_converter
 
     async def build(self) -> Client:
         if self._runtime is None:
             self._runtime = Runtime.default()
+
+        if self._data_converter:
+            self._client_kwargs["data_converter"] = self._data_converter
 
         return await Client.connect(
             target_host=self._target_host,

--- a/temporal_boost/temporal/runtime.py
+++ b/temporal_boost/temporal/runtime.py
@@ -1,5 +1,4 @@
 import logging
-import socket
 from collections.abc import Mapping
 
 from temporalio.runtime import (
@@ -17,67 +16,56 @@ from temporal_boost.temporal import config
 logger = logging.getLogger(__name__)
 
 
-def is_port_in_use(host: str, port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(1.0)
-        result = sock.connect_ex((host, port))
-        return result == 0
+class TemporalRuntimeBuilder:
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        logging: LoggingConfig | None = None,
+        metrics: OpenTelemetryConfig | PrometheusConfig | MetricBuffer | None = None,
+        global_tags: Mapping[str, str] | None = None,
+        attach_service_name: bool = True,
+        metric_prefix: str | None = None,
+        prometheus_bind_address: str | None = config.PROMETHEUS_BIND_ADDRESS,
+        prometheus_counters_total_suffix: bool | None = config.PROMETHEUS_COUNTERS_TOTAL_SUFFIX,
+        prometheus_unit_suffix: bool | None = config.PROMETHEUS_UNIT_SUFFIX,
+        prometheus_durations_as_seconds: bool | None = config.PROMETHEUS_DURATIONS_AS_SECONDS,
+    ) -> None:
+        self._logging = logging or LoggingConfig.default
+        self._metrics = metrics
 
+        self._global_tags = global_tags or {}
+        self._attach_service_name = attach_service_name
+        self._metric_prefix = metric_prefix
+        self._prometheus_bind_address = prometheus_bind_address
+        self._prometheus_counters_total_suffix = prometheus_counters_total_suffix
+        self._prometheus_unit_suffix = prometheus_unit_suffix
+        self._prometheus_durations_as_seconds = prometheus_durations_as_seconds
 
-def create_runtime(  # noqa: PLR0913
-    *,
-    logging: LoggingConfig | None = None,
-    metrics: OpenTelemetryConfig | PrometheusConfig | MetricBuffer | None = None,
-    global_tags: Mapping[str, str] | None = None,
-    attach_service_name: bool = True,
-    metric_prefix: str | None = None,
-    prometheus_bind_address: str | None = config.PROMETHEUS_BIND_ADDRESS,
-    prometheus_counters_total_suffix: bool | None = config.PROMETHEUS_COUNTERS_TOTAL_SUFFIX,
-    prometheus_unit_suffix: bool | None = config.PROMETHEUS_UNIT_SUFFIX,
-    prometheus_durations_as_seconds: bool | None = config.PROMETHEUS_DURATIONS_AS_SECONDS,
-) -> Runtime:
-    if logging is None:
-        logging = LoggingConfig.default
-    if global_tags is None:
-        global_tags = {}
+    def build(self) -> Runtime:
+        if self._metrics is None and self._prometheus_bind_address is not None:
+            self._metrics = PrometheusConfig(
+                bind_address=self._prometheus_bind_address,
+                counters_total_suffix=self._prometheus_counters_total_suffix or False,
+                unit_suffix=self._prometheus_unit_suffix or False,
+                durations_as_seconds=self._prometheus_durations_as_seconds or False,
+            )
 
-    if metrics is None and prometheus_bind_address is not None:
+        telemetry_config = TelemetryConfig(
+            logging=self._logging,
+            metrics=self._metrics,
+            global_tags=self._global_tags,
+            attach_service_name=self._attach_service_name,
+            metric_prefix=self._metric_prefix,
+        )
         try:
-            host, port_str = prometheus_bind_address.split(":")
-            port = int(port_str)
-        except Exception as exc:
-            raise ValueError("Invalid prometheus_bind_address format, expected 'host:port'") from exc
-
-        if is_port_in_use(host, port):
-            logger.warning(f"Port {port} on {host} is already in use. Disabling Prometheus metrics.")
-            metrics = None
-        else:
-            metrics = PrometheusConfig(
-                bind_address=prometheus_bind_address,
-                counters_total_suffix=prometheus_counters_total_suffix or False,
-                unit_suffix=prometheus_unit_suffix or False,
-                durations_as_seconds=prometheus_durations_as_seconds or False,
-            )
-
-    telemetry_config = TelemetryConfig(
-        logging=logging,
-        metrics=metrics,
-        global_tags=global_tags,
-        attach_service_name=attach_service_name,
-        metric_prefix=metric_prefix,
-    )
-    try:
-        return Runtime(telemetry=telemetry_config)
-    except ValueError as err:
-        err_msg = str(err)
-        if "Address already in use" in err_msg:
-            logger.warning("Prometheus exporter port is already in use. Disabling metrics for this process.")
-            telemetry_config_no_metrics = TelemetryConfig(
-                logging=logging,
-                metrics=None,
-                global_tags=global_tags,
-                attach_service_name=attach_service_name,
-                metric_prefix=metric_prefix,
-            )
-            return Runtime(telemetry=telemetry_config_no_metrics)
-        raise
+            return Runtime(telemetry=telemetry_config)
+        except ValueError as err:
+            err_msg = str(err)
+            if "Address already in use" in err_msg and self._prometheus_bind_address:
+                _, port_str = self._prometheus_bind_address.split(":")
+                logger.warning(
+                    f"Prometheus exporter port[{port_str}] is already in use. Disabling metrics for this process"
+                )
+                telemetry_config_no_metrics = TelemetryConfig()
+                return Runtime(telemetry=telemetry_config_no_metrics)
+            raise


### PR DESCRIPTION
- Replaced legacy _import_app_object and runner functions with updated process_runner usage.
- Updated CLI entry point to use "temporal_boost.cli.runner:cli_app" and removed __main__.py.
- Cleaned up code structure and improved import handling for module resolution.